### PR TITLE
Update to latest mediation test suite on android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -127,5 +127,5 @@ dependencies {
   // noinspection GradleDynamicVersion
   api 'com.facebook.react:react-native:+'
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.google.android.ads:mediation-test-suite:1.5.0'
+  implementation 'com.google.android.ads:mediation-test-suite:2.0.0'
 }


### PR DESCRIPTION
Appears to function well. 1.5.0 is no longer working with new Admob SDKs